### PR TITLE
Fix coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,5 @@ jobs:
           CI: true
           CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         with:
-          coverageCommand: npm run coverage --prefix /home/runner/work/speak-out-fe/speak-out-fe/client
+          coverageCommand: npm run coverage --prefix client
           coverageLocations: "client/coverage/lcov.info:lcov"

--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test -- --coverage || true",
+    "test": "react-scripts test",
     "eject": "react-scripts eject",
     "coverage": "CI=true npm run test -- --coverage || true"
   },
@@ -60,7 +60,11 @@
   "author": "",
   "license": "ISC",
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",


### PR DESCRIPTION
# Description

Fixed a couple minor issues:
- The extra `-- --coverage` argument on the `test` script was overriding the incoming `--coverage` argument from the `coverage` script.
- The `npm --prefix` is best made to be relative so it can run in any environment.